### PR TITLE
Conserta o timer do feedback de importação de dados

### DIFF
--- a/frontend/public/main.js
+++ b/frontend/public/main.js
@@ -180,7 +180,7 @@ async function uploadFile(file) {
 
     setTimeout(() => {
       loadHomePage();
-    }, 5000);
+    }, 10000);
   } catch (error) {
     console.error("Error:", error);
   }
@@ -232,5 +232,5 @@ function newDataCheck(rowCount) {
     } 
 
     flashMessage('Houve algum problema ao importar os dados.', 'error');
-  }, 6000);
+  }, 11000);
 }


### PR DESCRIPTION
Foram adicionados 5 segundos no timer onde fazemos uma nova requisição depois de importar um arquivo pelo webside. Antes a requisição era feita rápida demais não dando tempo de todos os dados serem importados, causando problema na mensagem flash no frontend.